### PR TITLE
Add some changes

### DIFF
--- a/fastapi_server_session/interfaces/base.py
+++ b/fastapi_server_session/interfaces/base.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 from abc import ABC, abstractmethod
+from datetime import timedelta
 
 
 class BaseSessionInterface(ABC):
@@ -34,7 +35,9 @@ class BaseSessionInterface(ABC):
         """
 
     @abstractmethod
-    def _set_session_data(self, session_id: str, data: dict):
+    def _set_session_data(
+        self, session_id: str, data: dict, expire: timedelta | None = None
+    ):
         """Stores session data  in a datastore."""
 
     @abstractmethod

--- a/fastapi_server_session/manager.py
+++ b/fastapi_server_session/manager.py
@@ -28,6 +28,12 @@ class SessionManager:
         self.interface = interface
 
     def use_session(self, session_id: str):
+        if not session_id:
+            raise ValueError("must provide session_id and cannot be an empty string")
+
+        if type(session_id) is not str:
+            raise TypeError("session_id must be a string")
+
         return Session(
             interface=self.interface,
             session_id=session_id,

--- a/fastapi_server_session/manager.py
+++ b/fastapi_server_session/manager.py
@@ -18,34 +18,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from fastapi import Request, Response
+
 from .interfaces.base import BaseSessionInterface
 from .session import Session
-
-import uuid
-
-
-def is_valid_uuid(val):
-    try:
-        uuid.UUID(str(val))
-        return True
-    except ValueError:
-        return False
 
 
 class SessionManager:
     def __init__(self, interface: BaseSessionInterface):
         self.interface = interface
 
-    def use_session(self, request: Request, response: Response):
-        session_id = str(request.cookies.get("session"))
-
-        if not is_valid_uuid(session_id):
-            return Session(request=request, response=response, interface=self.interface)
-
+    def use_session(self, session_id: str):
         return Session(
-            request=request,
-            response=response,
             interface=self.interface,
             session_id=session_id,
         )

--- a/fastapi_server_session/session.py
+++ b/fastapi_server_session/session.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import uuid
 from collections.abc import MutableMapping
 from typing import Any
 
@@ -41,8 +40,8 @@ class Session(MutableMapping):
         self.interface._set_session_data(session_id, {})
 
     def _session_check(self) -> None:
-        if not self.session_id or not self.interface._get_session_data(self.session_id):
-            self._initiate_session(str(uuid.uuid4()))
+        if not self.interface._get_session_data(self.session_id):
+            self._initiate_session(self.session_id)
 
     def clear(self) -> None:
         """Clears and deletes the session"""

--- a/fastapi_server_session/session.py
+++ b/fastapi_server_session/session.py
@@ -50,8 +50,22 @@ class Session(MutableMapping):
     def __setitem__(self, key, value) -> None:
         self._session_check()
         data = self.interface._get_session_data(self.session_id)
-        data[key] = value
-        self.interface._set_session_data(self.session_id, data)
+
+        expire = None
+
+        if type(value) is dict and value.get("_parse_"):
+            try:
+                data[key] = value["value"]
+            except KeyError:
+                raise ValueError(
+                    "dict must have the 'value' key with the value to be set"
+                )
+
+            expire = value.get("expire", None)
+        else:
+            data[key] = value
+
+        self.interface._set_session_data(self.session_id, data, expire=expire)
 
     def __getitem__(self, key) -> Any | None:
         try:


### PR DESCRIPTION
- Remove use of cookies
- session_id is always passed and not generated as it matches user id anyway.
- Allow for dict values to be passed and be parsed to obtain the value to store and other parameters like expire. eg.
 ```python
session["one"] = {
  "value": "123",
  "expire": timedelta(hours=2),
  "_parse_": True
}
```
Would mean the key one would have value 123 and would be set to expire in 2 hours. The expire only works on the redis interface for now since in mongodb the created_at is indexed and the expire is set only at instantiation.
